### PR TITLE
TEST: Add integration tests for advanced rules

### DIFF
--- a/tests/main_integration_tests.rs
+++ b/tests/main_integration_tests.rs
@@ -1,6 +1,8 @@
-// FILE: ./tests/main_integration_tests.rs
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::fs::File;
+use std::io::Write;
+use tempfile::Builder;
 
 #[test]
 fn test_alias_generation() {
@@ -40,4 +42,75 @@ fn test_debug_output() {
             predicate::str::contains("Retrieved command(s):")
                 .and(predicate::str::contains("git branch")),
         );
+}
+
+// Command with Quoted Arguments
+/// Tests if a command with quoted arguments is corrected properly.
+/// This ensures that the argument parsing logic (shlex) correctly handles quotes and spaces.
+#[test]
+fn test_command_with_quotes() {
+    let mut cmd = Command::cargo_bin("ohcrab").unwrap();
+    cmd.arg("--select-first")
+        .arg("--")
+        // Pass the entire command as a single argument to simulate shell behavior
+        .arg("git comit -m \"a message with spaces\"")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("git commit -m \"a message with spaces\""));
+}
+
+// Command Corrected by `no_command` Rule
+/// Tests a command with a typo in the executable name itself.
+/// This relies on the `no_command` rule, which has a higher priority, to suggest a correction
+/// from the list of available system executables.
+#[test]
+fn test_executable_typo_correction() {
+    let mut cmd = Command::cargo_bin("ohcrab").unwrap();
+    cmd.arg("--select-first")
+        .arg("--")
+        .arg("gti") // Typo for "git"
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("git status"));
+}
+
+// Rule that Creates a Directory (`no_such_file`)
+/// Tests the `no_such_file` rule for `cp`, which fails when the destination directory doesn't exist.
+/// The corrected command should first create the directory and then execute the original command.
+#[test]
+fn test_command_creating_directory() {
+    // Setup a temporary directory and a file to copy
+    let temp_dir = Builder::new().prefix("ohcrab_test").tempdir().unwrap();
+    let file_path = temp_dir.path().join("file.txt");
+    let mut file = File::create(&file_path).unwrap();
+    writeln!(file, "hello").unwrap();
+
+    let mut cmd = Command::cargo_bin("ohcrab").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("--select-first")
+        .arg("--")
+        .arg("cp")
+        .arg("file.txt")
+        .arg("non_existent_dir/file.txt")
+        .assert()
+        .success()
+        // Assert that the suggested command includes `mkdir -p`
+        .stdout(predicate::str::contains(
+            "mkdir -p non_existent_dir && cp file.txt non_existent_dir/file.txt",
+        ));
+}
+
+// Piped Command Correction
+/// Tests if `ohcrab` can correct the failing part of a piped command.
+/// The `no_command` rule should correct `lss` to `ls`.
+#[test]
+fn test_piped_command() {
+    let mut cmd = Command::cargo_bin("ohcrab").unwrap();
+    cmd.arg("--select-first")
+        .arg("--")
+        .arg("gitt status | grep foo") // `gitt` is a less ambiguous typo for `git`
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("git status | grep foo"));
 }


### PR DESCRIPTION
This commit adds a suite of new integration tests to validate advanced correction logic and fix regressions. The tests cover a range of common scenarios that require more complex rule handling.

The new tests include:

* **Commands with Quoted Arguments**: Ensures that `shlex` correctly parses commands containing quoted arguments with spaces (e.g., `git commit -m "a message"`).
* **Piped Commands**: Verifies that the tool can correct a command within a pipeline (e.g., `gitt status | grep foo`).
* **Executable Typo Correction**: Tests the `no_command` rule's ability to correct typos in the executable name itself, such as `gti` to `git`.
* **`no_such_file` Rule**: Validates that a failed `cp` command is correctly fixed by prepending `mkdir -p` when the destination directory doesn't exist.

These tests improve the robustness of the application and prevent future regressions.