### PR TITLE
CICD: Streamlined Release & Crates.io CD Workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,216 +1,102 @@
-on:
-  push:
-    tags:
-      - "v*.*.*"
+name: Release
 
-name: CD
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
 
 jobs:
-  build_and_test_linux:
-    name: Build and Test (Linux)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: taiki-e/install-action@nextest
-      - name: 'Build and test'
-        run: cargo nextest run --workspace --all-features
-
-  build_and_test_macos:
-    name: Build and Test (MacOS)
-    runs-on: macos-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4.1.1
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - uses: taiki-e/install-action@nextest
-      - name: 'Build and test'
-        run: cargo nextest run --workspace --all-features
-
-
-  build_and_release:
-    name: Build and Release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
+  create-release-artifacts:
+    name: Build Release Artifacts
+    # Only run on version tags
+    if: startsWith(github.event.release.tag_name, 'v')
     strategy:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os_name: Linux_x86_64
-          - target: i686-unknown-linux-gnu
-            os_name: Linux_32-bit
-          - target: i686-unknown-freebsd
-            os_name: freebsd_32-bit
-          - target: x86_64-unknown-freebsd
-            os_name: freebsd_x86_64
+            os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os_name: Linux_arm64
-          # - target: x86_64-apple-darwin
-          #   os_name: Darwin_x86_64
-          # - target: aarch64-apple-darwin
-          #   os_name: Darwin_arm64
-          # - target: aarch64-unknown-freebsd
-          #   os_name: freebsd_arm64
-          # - target: armv6-unknown-freebsd
-          #   os_name: freebsd_armv6
-          # - target: armv6-unknown-linux-gnueabihf
-          #   os_name: Linux_armv6
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4.1.1
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
-
-      - name: Install cross
-        run: cargo install cross
-
-      - name: Build
-        run: cross build --target ${{ matrix.target }} --release
-
-      - name: Rename binary
-        run: |
-          # Convert to lower case and replace '-' with '_'
-          target=${{ matrix.target }}
-          target_modified=$(echo "$target" | tr '[:upper:]' '[:lower:]' | tr '-' '_')
-
-          # Get the current tag
-          current_tag=$(git describe --tags)
-          prefix=_"${target_modified}"_"${current_tag}".bin
-
-          # Rename the file
-          cd ./target/${{ matrix.target }}/release/
-          mv ohcrab ohcrab"$prefix"
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: ./target/${{ matrix.target }}/release/ohcrab*.bin
-
-  build_and_release_macos:
-    name: Build and Release
-    runs-on: macos-13
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        include:
+            os: ubuntu-latest
           - target: x86_64-apple-darwin
-            os_name: Darwin_x86_64
+            os: macos-latest
           - target: aarch64-apple-darwin
-            os_name: Darwin_arm64
+            os: macos-latest
+          # You can add Windows here if you support it
+          # - target: x86_64-pc-windows-msvc
+          #   os: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4.1.1
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
 
-      # - name: Add target
-      #   run: rustup target add ${{ matrix.target }}
-
-      - name: Install the linker
-        run: brew install FiloSottile/musl-cross/musl-cross
-
-      # - name: Install cross
-      #   run: cargo install cross
-
-      - name: Build
-        run: cargo build --target ${{ matrix.target }} --release
-
-      - name: List files
-        run: ls ./target/${{ matrix.target }}/release/
-
-      - name: Rename binary
+      - name: Setup cross-compilation for Linux aarch64
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
-          # Convert to lower case and replace '-' with '_'
-          target=${{ matrix.target }}
-          target_modified=$(echo "$target" | tr '[:upper:]' '[:lower:]' | tr '-' '_')
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
-          # Get the current tag
-          current_tag=$(git describe --tags)
-          prefix=_"${target_modified}"_"${current_tag}".bin
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.target }}
+        env:
+          # Required for cross-compiling on Linux
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
-          # Rename the file
-          cd ./target/${{ matrix.target }}/release/
-          mv ohcrab ohcrab"$prefix"
+      - name: Prepare artifacts for release
+        shell: bash
+        run: |
+          # The binary name from your Cargo.toml
+          BINARY_NAME="ohcrab"
+          # The standardized artifact name for the release
+          ARTIFACT_FILENAME="${BINARY_NAME}-${{ matrix.target }}"
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
+          EXECUTABLE_PATH="./target/${{ matrix.target }}/release/${BINARY_NAME}"
+
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            ARTIFACT_FILENAME="${ARTIFACT_FILENAME}.exe"
+            mv "${EXECUTABLE_PATH}.exe" "./${ARTIFACT_FILENAME}"
+          else
+            mv "${EXECUTABLE_PATH}" "./${ARTIFACT_FILENAME}"
+          fi
+
+          # Set environment variables for the next step
+          echo "ASSET_PATH=./${ARTIFACT_FILENAME}" >> $GITHUB_ENV
+          echo "ASSET_NAME=${ARTIFACT_FILENAME}" >> $GITHUB_ENV
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ./target/${{ matrix.target }}/release/ohcrab*.bin
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.ASSET_PATH }}
+          asset_name: ${{ env.ASSET_NAME }}
+          asset_content_type: application/octet-stream
 
-  crates_io_publish:
-    name: Publish (crates.io)
-    needs:
-      # - audit
-      - build_and_test_linux
-      - build_and_test_macos
-      - build_and_release
-      - build_and_release_macos
-
+  publish-to-crates:
+    name: Publish to crates.io
+    needs: create-release-artifacts
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
-    timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: cargo-release Cache
-        id: cargo_release_cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/bin/cargo-release
-          key: ${{ runner.os }}-cargo-release
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-      - run: cargo install cargo-release
-        if: steps.cargo_release_cache.outputs.cache-hit != 'true'
+      # Use --dry-run for pre-releases to avoid publishing them
+      - name: Dry-run publish to crates.io (Pre-release)
+        if: github.event.release.prerelease
+        run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }} --dry-run
 
-      - name: cargo login
-        run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
-
-      # allow-branch HEAD is because GitHub actions switches
-      # to the tag while building, which is a detached head
-
-      # Publishing is currently messy, because:
-      #
-      # * `peace_rt_model_core` exports `NativeError` or `WebError` depending on the target.
-      # * `peace_rt_model_web` fails to build when publishing the workspace for a native target.
-      # * `peace_rt_model_web` still needs its dependencies to be published before it can be
-      #    published.
-      # * `peace_rt_model_hack` needs `peace_rt_model_web` to be published before it can be
-      #    published.
-      #
-      # We *could* pass through `--no-verify` so `cargo` doesn't build the crate before publishing,
-      # which is reasonable, since this job only runs after the Linux, Windows, and WASM builds
-      # have passed.
-      - name: "cargo release publish"
-        run: |-
-          cargo release \
-            publish \
-            --workspace \
-            --all-features \
-            --allow-branch HEAD \
-            --no-confirm \
-            --no-verify \
-            --execute
+      # Only publish full releases
+      - name: Publish to crates.io (Full Release)
+        if: "!github.event.release.prerelease"
+        run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   create-release-artifacts:
     name: Build Release Artifacts
-    # Only run on version tags
     if: startsWith(github.event.release.tag_name, 'v')
     strategy:
       matrix:
@@ -19,13 +18,14 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: i686-unknown-linux-gnu
+            os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          # You can add Windows here if you support it
-          # - target: x86_64-pc-windows-msvc
-          #   os: windows-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -36,26 +36,27 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Setup cross-compilation for Linux aarch64
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Setup cross-compilation for Linux
+        if: matrix.os == 'ubuntu-latest' && matrix.target != 'x86_64-unknown-linux-gnu'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+          elif [ "${{ matrix.target }}" = "i686-unknown-linux-gnu" ]; then
+            sudo apt-get install -y gcc-i686-linux-gnu
+          fi
 
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }}
         env:
-          # Required for cross-compiling on Linux
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER: i686-linux-gnu-gcc
 
       - name: Prepare artifacts for release
         shell: bash
         run: |
-          # The binary name from your Cargo.toml
           BINARY_NAME="ohcrab"
-          # The standardized artifact name for the release
           ARTIFACT_FILENAME="${BINARY_NAME}-${{ matrix.target }}"
-
           EXECUTABLE_PATH="./target/${{ matrix.target }}/release/${BINARY_NAME}"
 
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
@@ -65,7 +66,6 @@ jobs:
             mv "${EXECUTABLE_PATH}" "./${ARTIFACT_FILENAME}"
           fi
 
-          # Set environment variables for the next step
           echo "ASSET_PATH=./${ARTIFACT_FILENAME}" >> $GITHUB_ENV
           echo "ASSET_NAME=${ARTIFACT_FILENAME}" >> $GITHUB_ENV
 
@@ -91,12 +91,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # Use --dry-run for pre-releases to avoid publishing them
       - name: Dry-run publish to crates.io (Pre-release)
         if: github.event.release.prerelease
         run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }} --dry-run
 
-      # Only publish full releases
       - name: Publish to crates.io (Full Release)
         if: "!github.event.release.prerelease"
         run: cargo publish --token ${{ secrets.CRATES_IO_API_TOKEN }}


### PR DESCRIPTION
This PR refactors the CD workflow (`.github/workflows/cd.yml`) for releases, focusing on efficiency and expanded platform support.

**Key Changes:**

*   **Release-Driven Trigger:** Workflow now activates on GitHub Release creation (`release: types: [created]`).
*   **Consolidated Artifact Build:** A single, matrix-driven `create-release-artifacts` job builds binaries for Linux (x86_64, aarch64, i686), macOS (x86_64, aarch64), and now Windows (x86_64). It includes improved cross-compilation setup and standardizes artifact naming and upload.
*   **Simplified Crates.io Publish:** The `publish-to-crates` job now uses `cargo publish` directly, with conditional dry-runs for pre-releases, removing `cargo-release` dependency and old flags.
*   **Clearer Scope:** This workflow is now dedicated to release artifact generation and crates.io publishing, separating it from general testing.